### PR TITLE
Add constrained impl support and fix recursive Show dispatch

### DIFF
--- a/programs/test.ls
+++ b/programs/test.ls
@@ -1,6 +1,23 @@
-impl Semigroup for Bool where
-  let mappend x y = x
-  let (++) x y = mappend x y
+type Maybe<a> =
+  | Nothing
+  | Just of a
+
+impl Show for Maybe<a> requires Show<a> where
+  let show o =
+    case o do
+    | Nothing -> "Nothing"
+    | Just v -> "Just(" ^ (show v) ^ ")"
 end
 
-let _ = println (true ++ false)
+type rec LinkedList<a> =
+  | Nil
+  | Cons of (a, LinkedList<a>)
+
+
+impl Show for LinkedList<a> requires Show<a> where
+  let rec show l =
+    case l do
+    | Nil -> "Nil"
+    | Cons (h, t) -> "Cons " ^ (show h) ^ " " ^ (show t)
+end
+

--- a/src/Expr.ml
+++ b/src/Expr.ml
@@ -64,7 +64,8 @@ type defn =
       * (string * int) list
       * (string * compound_type) list
       * trait_item list
-  | InstanceDef of string * compound_type * (string * expr) list
+  | InstanceDef of
+      string * compound_type * (string * compound_type) list * (string * expr) list
   | TypeDef of string * string list * compound_type
   | SumTypeDef of string * string list * (string * compound_type option) list
   | SumTypeDefRec of string * string list * (string * compound_type option) list

--- a/src/ceval.ml
+++ b/src/ceval.ml
@@ -605,6 +605,20 @@ and apply_function_value env v_fn v_arg : value eval_result =
 
 and dispatch_typeclass_method_args env cls_name method_name (args : value list)
     : value eval_result =
+  let is_pending_value = function
+    | TypeClassMethodPending _ -> true
+    | _ -> false
+  in
+  let is_acceptable_result (v : value) : bool =
+    if is_pending_value v then false
+    else
+      match (cls_name, method_name) with
+      | "Show", "show" -> (
+          match v with
+          | StringValue _ -> true
+          | _ -> false)
+      | _ -> true
+  in
   let apply_all (method_fn : value) : value eval_result =
     let rec go fn = function
       | [] -> return fn
@@ -622,7 +636,11 @@ and dispatch_typeclass_method_args env cls_name method_name (args : value list)
   let try_from_tau (tau : mono_type) : value eval_result option =
     let dict_name = dict_for_instance ~class_name:cls_name tau in
     match method_for_dict dict_name with
-    | Some method_fn -> Some (apply_all method_fn)
+    | Some method_fn -> (
+        match apply_all method_fn with
+        | Ok v when not (is_acceptable_result v) -> None
+        | Ok _ as r -> Some r
+        | result -> Some result)
     | None -> None
   in
   let try_from_empty_list_shape () : value eval_result option =
@@ -632,7 +650,11 @@ and dispatch_typeclass_method_args env cls_name method_name (args : value list)
       | (k, _) :: rest ->
           if String.starts_with ~prefix k then
             match method_for_dict k with
-            | Some method_fn -> Some (apply_all method_fn)
+            | Some method_fn -> (
+                match apply_all method_fn with
+                | Ok v when not (is_acceptable_result v) -> scan rest
+                | Ok v -> Some (Ok v)
+                | result -> Some result)
             | None -> scan rest
           else scan rest
     in
@@ -644,12 +666,13 @@ and dispatch_typeclass_method_args env cls_name method_name (args : value list)
       | [] -> None
       | (k, _) :: rest ->
           if String.starts_with ~prefix k then
-            match method_for_dict k with
+            (match method_for_dict k with
             | Some method_fn -> (
                 match apply_all method_fn with
+                | Ok v when not (is_acceptable_result v) -> scan rest
                 | Ok v -> Some (Ok v)
                 | Error _ -> scan rest)
-            | None -> scan rest
+            | None -> scan rest)
           else scan rest
     in
     scan env
@@ -932,6 +955,20 @@ and expr_of_pat : c_pat -> c_expr = function
     @param env The environment to evaluate in
     @return The new bindings introduced by the definition *)
 and eval_defn (d : c_defn) (env : env) : env eval_result =
+  let rec backpatch_recursive_closures (new_bindings : env) (v : value) : unit =
+    match v with
+    | RecursiveFunctionClosure (env_ref, _, _, _) ->
+        env_ref := new_bindings @ !env_ref
+    | RecordValue fields ->
+        List.iter
+          (fun (_, field_v) -> backpatch_recursive_closures new_bindings field_v)
+          fields
+    | VectorValue vs | ListValue vs ->
+        List.iter (backpatch_recursive_closures new_bindings) vs
+    | IntegerValue _ | FloatValue _ | StringValue _ | BooleanValue _
+    | CharValue _ | UnitValue | FunctionClosure _ | BuiltInFunction _
+    | TypeClassMethod _ | TypeClassMethodPending _ | VariantValue _ -> ()
+  in
   match d with
   | CDefn (pat, _, _, body, _, _) -> (
       (* Evaluate the body in the current environment *)
@@ -939,7 +976,11 @@ and eval_defn (d : c_defn) (env : env) : env eval_result =
       (* Try to bind the pattern to the value *)
       match bind_pat pat value with
       | None -> Error (OtherError "eval_defn: pattern match failed")
-      | Some new_bindings -> new_bindings |> return)
+      | Some new_bindings ->
+          List.iter
+            (fun (_, v) -> backpatch_recursive_closures new_bindings v)
+            new_bindings;
+          new_bindings |> return)
   | CDefnRec (pat, _, _, body, _, _) -> (
       (* For recursive definitions, we need to create a recursive closure *)
       let* value = eval_c_expr body env in

--- a/src/condense.ml
+++ b/src/condense.ml
@@ -646,7 +646,9 @@ let dict_bindrec_payload ~(meth : string) ~(intid : string) (e : c_expr) :
     (c_type option * c_expr * c_type option) option =
   match e with
   | EBindRec (CIdPat nm, ta, e1, EId (tail, _), rt)
-    when String.equal nm meth && String.equal tail intid -> Some (ta, e1, rt)
+    when String.equal nm meth
+         && (String.equal tail intid || String.equal tail meth) ->
+      Some (ta, e1, rt)
   | _ -> None
 
 (** Whether [e] mentions [id] as [EId] (trait dict internals are unique). *)
@@ -902,7 +904,7 @@ let condense_program ?(user_id_byte_min_after_prelude : (int * int) option)
         after_top_level_defn ();
         walk ((name, entry) :: classes) seen_ctors seen_instances (decl :: acc)
           rest
-    | InstanceDef (cls, inst_ct, impls) :: rest ->
+    | InstanceDef (cls, inst_ct, impl_requires, impls) :: rest ->
         before_top_level_defn ();
         (
         match List.assoc_opt cls classes with
@@ -921,6 +923,17 @@ let condense_program ?(user_id_byte_min_after_prelude : (int * int) option)
                 let subst mt =
                   Type_arity.substitute_instance_in_mono ~written_var:w
                     ~inst:inst_mono arity mt
+                in
+                let requires_mono =
+                  List.map
+                    (fun (req_cls, req_ct) ->
+                      match List.assoc_opt req_cls classes with
+                      | None ->
+                          failwith
+                            ("forge: impl requires unknown trait '" ^ req_cls
+                           ^ "'")
+                      | Some _ -> (req_cls, condense_compound_type req_ct))
+                    impl_requires
                 in
                 let slug = mono_type_slug inst_mono in
                 let impl_names = List.map fst impls in
@@ -1024,7 +1037,11 @@ let condense_program ?(user_id_byte_min_after_prelude : (int * int) option)
                         | None ->
                             if expr_refs_c_id intid e then
                               EBindRec (CIdPat intid, None, e, acc, None)
-                            else EBind (CIdPat intid, None, e, acc, None))
+                            else
+                              (match e with
+                              | EFunction _ ->
+                                  EBindRec (CIdPat intid, None, e, acc, None)
+                              | _ -> EBind (CIdPat intid, None, e, acc, None)))
                       ordered record
                   in
                   match topo_dict_methods ~dispatch_d names condensed with
@@ -1071,7 +1088,7 @@ let condense_program ?(user_id_byte_min_after_prelude : (int * int) option)
                       let cdefn =
                         CDefn
                           ( CIdPat dict_name,
-                            [],
+                            requires_mono,
                             Some (Mono expected),
                             body,
                             None,

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1615,6 +1615,44 @@ end = struct
         | Id s -> Some s
         | _ -> None)
     in
+    let impl_requires_and_where_parser :
+        ((string * compound_type) list * bool) parser =
+      (let* () = expect_token Requires in
+       let* rs = parse_sep_delim requires_super_parser Comma in
+       return (rs, false))
+      <|>
+      (let* () = expect_token Where in
+       let* starts_let = check_tokens Let in
+       if starts_let then return ([], true)
+       else
+         let* rs = parse_sep_delim requires_super_parser Comma in
+         let* () = expect_token Where in
+         return (rs, true))
+      <|> return ([], false)
+    in
+    let impl_body_where_parser (head_ty : compound_type) : defn parser =
+      let* requires, has_body_where = impl_requires_and_where_parser in
+      let* () = if has_body_where then return () else expect_token Where in
+      let* impls = parse_one_or_more_opt_commas impl_row_parser in
+      let* () = expect_token End in
+      return (InstanceDef (cls, head_ty, requires, impls))
+    in
+    let impl_body_brace_parser (head_ty : compound_type) : defn parser =
+      let* requires =
+        (let* () = expect_token Requires in
+         let* rs = parse_sep_delim requires_super_parser Comma in
+         return rs)
+        <|>
+        (let* () = expect_token Where in
+         let* rs = parse_sep_delim requires_super_parser Comma in
+         return rs)
+        <|> return []
+      in
+      let* () = expect_token LBrace in
+      let* impls = parse_one_or_more_opt_commas impl_row_parser in
+      let* () = expect_token RBrace in
+      return (InstanceDef (cls, head_ty, requires, impls))
+    in
     (let* () =
        expect_token_get_data (function
          | Relop s when s = "<" -> Some ()
@@ -1626,22 +1664,11 @@ end = struct
          | Relop s when s = ">" -> Some ()
          | _ -> None)
      in
-     let* () = expect_token Where in
-     let* impls = parse_one_or_more_opt_commas impl_row_parser in
-     let* () = expect_token End in
-     return (InstanceDef (cls, head_ty, impls)))
+     impl_body_where_parser head_ty)
     <|>
     let* () = expect_token For in
     let* head_ty = CompoundTypeParser.compound_type_parser in
-    (let* () = expect_token LBrace in
-     let* impls = parse_one_or_more_opt_commas impl_row_parser in
-     let* () = expect_token RBrace in
-     return (InstanceDef (cls, head_ty, impls)))
-    <|>
-    let* () = expect_token Where in
-    let* impls = parse_one_or_more_opt_commas impl_row_parser in
-    let* () = expect_token End in
-    return (InstanceDef (cls, head_ty, impls))
+    (impl_body_brace_parser head_ty) <|> impl_body_where_parser head_ty
 
   let constructor_parser : (string * compound_type option) parser =
     let* () = expect_token Pipe in

--- a/src/tostring.ml
+++ b/src/tostring.ml
@@ -616,11 +616,18 @@ and string_of_defn (d : defn) (level : int) =
       ^ String.concat ", "
           (List.map (fun it -> string_of_trait_item it (level + 1)) items)
       ^ "])"
-  | InstanceDef (cls, head_ty, impls) ->
+  | InstanceDef (cls, head_ty, requires, impls) ->
       "InstanceDef ("
       ^ cls
       ^ ", "
       ^ string_of_compound_type head_ty (level + 1)
+      ^ ", requires ["
+      ^ String.concat ", "
+          (List.map
+             (fun (c, ct) ->
+               c ^ " " ^ string_of_compound_type ct (level + 1))
+             requires)
+      ^ "]"
       ^ ", ["
       ^ String.concat ", "
           (List.map

--- a/src/typecheck.ml
+++ b/src/typecheck.ml
@@ -2832,6 +2832,17 @@ let rec primary_class_constraint (t : c_type) : string option =
   | PolyType (_, inner) -> primary_class_constraint inner
   | _ -> None
 
+let rec all_class_constraints (t : c_type) : string list =
+  match t with
+  | Constrained (preds, inner) ->
+      let here = List.map fst preds in
+      let rest = all_class_constraints inner in
+      List.fold_left
+        (fun acc c -> if List.mem c acc then acc else acc @ [ c ])
+        here rest
+  | PolyType (_, inner) -> all_class_constraints inner
+  | Mono _ -> []
+
 let rec extract_class_param_and_mono_template (class_name : string) (t : c_type)
     : (string * mono_type) option =
   match t with
@@ -3112,28 +3123,47 @@ let rec elaborate_expr (static_env : static_env) (type_env : type_env) :
 and elaborate_constrained_body (static_env : static_env)
     (type_env : type_env) (name : string) (body : c_expr) : c_expr =
   match List.assoc_opt name static_env with
-  | Some sch when scheme_has_class_constraint sch -> (
-      match primary_class_constraint sch with
-      | Some cls ->
+  | Some sch when scheme_has_class_constraint sch ->
+      let constrained_classes = all_class_constraints sch in
+      let body' = elaborate_expr static_env type_env body in
+      List.fold_right
+        (fun cls acc_body ->
           let dict_param = "__dict_" ^ cls in
           let method_names = class_method_names ~static_env ~class_name:cls in
-          let body' = elaborate_expr static_env type_env body in
-          let body'' =
-            subst_methods_with_dict_access ~dict_param ~method_names body'
+          let rewritten =
+            subst_methods_with_dict_access ~dict_param ~method_names acc_body
           in
-          if body' = body'' then body''
-          else EFunction (CIdPat dict_param, None, body'')
-      | None -> elaborate_expr static_env type_env body)
+          if rewritten = acc_body then acc_body
+          else EFunction (CIdPat dict_param, None, rewritten))
+        constrained_classes body'
   | _ -> elaborate_expr static_env type_env body
 
 and elaborate_defn (static_env : static_env) (type_env : type_env) d : c_defn =
   match d with
   | CDefn (CIdPat name as pat, cs, a, body, r, n) ->
-      CDefn (pat, cs, a, elaborate_constrained_body static_env type_env name body, r, n)
+      if String.starts_with ~prefix:"__forge_dict_" name then
+        CDefn (pat, cs, a, elaborate_expr static_env type_env body, r, n)
+      else
+        CDefn
+          ( pat,
+            cs,
+            a,
+            elaborate_constrained_body static_env type_env name body,
+            r,
+            n )
   | CDefn (pat, cs, a, body, r, n) ->
       CDefn (pat, cs, a, elaborate_expr static_env type_env body, r, n)
   | CDefnRec (CIdPat name as pat, cs, a, body, r, n) ->
-      CDefnRec (pat, cs, a, elaborate_constrained_body static_env type_env name body, r, n)
+      if String.starts_with ~prefix:"__forge_dict_" name then
+        CDefnRec (pat, cs, a, elaborate_expr static_env type_env body, r, n)
+      else
+        CDefnRec
+          ( pat,
+            cs,
+            a,
+            elaborate_constrained_body static_env type_env name body,
+            r,
+            n )
   | CDefnRec (pat, cs, a, body, r, n) ->
       CDefnRec (pat, cs, a, elaborate_expr static_env type_env body, r, n)
   | CDefnMutRec defs ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -1562,6 +1562,27 @@ let program_typecheck_tests =
                     "parse incomplete: %d defns, %d rem, first rem=%s"
                     (List.length defs) (List.length rem) first_tok)
            | None -> assert_failure "program_parser returned None" );
+         ( "impl with where constraints tokenizes and parses to EOF" >:: fun _ ->
+           let s =
+             "impl Show for Option<a> where Show<a> where let show o = o end\n"
+           in
+           let tokens =
+             lex (s |> String.to_seq |> List.of_seq)
+             |> List.map (fun t -> t.token_type)
+           in
+           match Language.Parser.ProgramParser.program_parser tokens with
+           | Some ([ Language.Expr.InstanceDef _ ], rem) when rem = [] -> ()
+           | Some (defs, rem) ->
+               let first_tok =
+                 match rem with
+                 | h :: _ -> Language.Lex.string_of_token_type h
+                 | [] -> ""
+               in
+               assert_failure
+                 (Printf.sprintf
+                    "parse incomplete: %d defns, %d rem, first rem=%s"
+                    (List.length defs) (List.length rem) first_tok)
+           | None -> assert_failure "program_parser returned None" );
        ]
 
 let program_expression_type_tests =
@@ -1614,6 +1635,95 @@ let program_expression_type_tests =
              |}
              ~expr:"fmap (fn x -> x + 1) (Some 10)"
              ~expected_type:"Option<Int>" );
+         ( "Show Option with impl where-constraint" >:: fun _ ->
+           assert_expression_has_type
+             ~program:
+               {|
+               inter Show <a> {
+                 val show : a -> String
+               }
+               impl Show for Int where
+                 let show x = int_to_str x
+               end
+               type Option<a> =
+                 | None
+                 | Some of a
+               impl Show for Option<a> where Show<a> where
+                 let show o =
+                   case o do
+                   | None -> "None"
+                   | Some v -> "Some(" ^ show v ^ ")"
+               end
+             |}
+             ~expr:"show (Some 10)" ~expected_type:"String" );
+         ( "Show Option constrained impl evaluates" >:: fun _ ->
+           assert_expression_has_value
+             ~program:
+               {|
+               inter Show <a> {
+                 val show : a -> String
+               }
+               impl Show for Int where
+                 let show x = int_to_str x
+               end
+               type Option<a> =
+                 | None
+                 | Some of a
+               impl Show for Option<a> requires Show<a> where
+                 let show o =
+                   case o do
+                   | None -> "None"
+                   | Some v -> "Some(" ^ show v ^ ")"
+               end
+             |}
+             ~expr:"show (Some 10)" ~expected_value:"\"Some(10)\"" );
+         ( "Show Maybe nested constrained impl evaluates" >:: fun _ ->
+           assert_expression_has_value
+             ~program:
+               {|
+               inter Show <a> {
+                 val show : a -> String
+               }
+               impl Show for Int where
+                 let show x = int_to_str x
+               end
+               type Maybe<a> =
+                 | Nothing
+                 | Just of a
+               impl Show for Maybe<a> requires Show<a> where
+                 let show o =
+                   case o do
+                   | Nothing -> "Nothing"
+                   | Just v -> "Just(" ^ show v ^ ")"
+               end
+             |}
+             ~expr:"show (Just (Just 10))"
+             ~expected_value:"\"Just(Just(10))\"" );
+         ( "Show Maybe nested constrained impl with Show String present" >:: fun _ ->
+           assert_expression_has_value
+             ~program:
+               {|
+               inter Show <a> {
+                 val show : a -> String
+               }
+               impl Show for Int where
+                 let show x = int_to_str x
+               end
+               impl Show for String where
+                 let show s = s
+               end
+               type Maybe<a> =
+                 | Nothing
+                 | Just of a
+               impl Show for Maybe<a> requires Show<a> where
+                 let show o =
+                   case o do
+                   | Nothing -> "Nothing"
+                   | Just v -> "Just(" ^ show v ^ ")"
+               end
+             |}
+             ~expr:"show (Just (Just 10))"
+             ~expected_value:"\"Just(Just(10))\"" );
          ( "Semigroup Int sappend" >:: fun _ ->
            assert_expression_has_type
              ~program:


### PR DESCRIPTION
## Summary
This PR adds support for trait constraints on `impl` declarations in the interpreter/typechecker pipeline, and fixes runtime dispatch issues for recursive constrained `Show` instances.

### What’s included
- Added `impl` constraint support in AST and parser:
  - Supports forms like:
    - `impl Show for Option<a> requires Show<a> where ... end`
    - `impl Show for Option<a> where Show<a> where ... end`
- Wired impl constraints into condensation/typechecking so generated dict definitions carry the required class predicates.
- Improved constrained elaboration handling for multiple class constraints.
- Fixed recursive method handling in dictionary generation for `let rec` methods.
- Fixed runtime class-method dispatch edge cases:
  - Avoid accepting unresolved pending method values as successful dispatch.
  - Avoid bad fallback results for `Show.show` that don’t produce `String`.
  - Backpatch recursive closures inside top-level bound records (dict values), so recursive dictionary methods resolve correctly.

## Bug fixed
Preloading files with recursive constrained `Show` impls (e.g. `LinkedList<a>`) could fail with `Language.Typecheck.TypeFailure` or runtime `eval_bop: unimplemented` for nested values like `show (Just (Just 10))`. This PR fixes both.

## Tests / validation
- `dune test` passes (`306` tests).
- Manual REPL validation:
  - `show Nothing` -> `"Nothing"`
  - `show (Just 10)` -> `"Just(10)"`
  - `show (Just (Just 10))` -> `"Just(Just(10))"`
  - Recursive constrained list-style show now preloads and evaluates correctly.
