### PR TITLE
Fix hover resilience and improve type/definition hover

### DIFF
--- a/bin/forge_hover.ml
+++ b/bin/forge_hover.ml
@@ -5,7 +5,7 @@
     [prelude] is [1]/[true] to prepend the prelude (default for IDE), or
     [0]/[false] for raw buffer only.
 
-    On success: prints the type string (no trailing newline) to stdout.
+    On success: prints [TYPE\t...] or [DEF\t...] (no trailing newline) to stdout.
     On failure: prints [ERROR: ...] to stdout and exits 1. *)
 
 let read_all_stdin () =
@@ -42,11 +42,9 @@ let () =
       exit 2
   in
   let source = read_all_stdin () in
-  match
-    Language.Hover_query.hover_type_for_identifier ~prelude ~src_path ~source
-      ~line0 ~char0
-  with
-  | Ok s -> print_string s
+  match Language.Hover_query.hover_for_position ~prelude ~src_path ~source ~line0 ~char0 with
+  | Ok (Language.Hover_query.HoverType, s) -> Printf.printf "TYPE\t%s" s
+  | Ok (Language.Hover_query.HoverDefinition, s) -> Printf.printf "DEF\t%s" s
   | Error msg ->
       Printf.printf "ERROR: %s" msg;
       exit 1

--- a/src/hover_query.ml
+++ b/src/hover_query.ml
@@ -1044,24 +1044,113 @@ let rec typecheck_defns_hover static_env type_env ctor_env defns :
 
 let rec walk_defns (acc_env : static_env) (acc_te : type_env) (user_byte_lo : int)
     (lex_id : string option) (offset : int) (full_tokens : Lex.token list)
-    (defs : c_defn list) : string option =
+    ~(prelude_defn_cap_count : int) ~(idx : int) (defs : c_defn list) :
+    string option =
+  let safe_hover_in_defn env te d0 =
+    try hover_in_defn env te user_byte_lo lex_id offset full_tokens d0
+    with _ -> None
+  in
   match defs with
   | [] -> None
   | d :: rest -> (
-      match generate_defn acc_env acc_te d with
-      | Error _ -> None
-      | Ok (nb, _, _) ->
+      let gen_res =
+        try Some (generate_defn acc_env acc_te d) with _ -> None
+      in
+      match gen_res with
+      | None | Some (Error _) -> (
+          (* Keep hover working even when this definition fails to typecheck.
+             Try hovering within the failing defn using the accumulated prefix
+             environment, then continue scanning later defs. *)
+          match safe_hover_in_defn acc_env acc_te d with
+          | Some _ as r -> r
+          | None ->
+              walk_defns acc_env acc_te user_byte_lo lex_id offset full_tokens
+                ~prelude_defn_cap_count ~idx:(idx + 1) rest)
+      | Some (Ok (nb, _, _)) ->
           let env_for_hover = nb @ acc_env in
+          let skip_hover_in_this_defn =
+            user_byte_lo > 0 && offset >= user_byte_lo && idx < prelude_defn_cap_count
+          in
           ( match
-              hover_in_defn env_for_hover acc_te user_byte_lo lex_id offset full_tokens d
+              if skip_hover_in_this_defn then None
+              else safe_hover_in_defn env_for_hover acc_te d
             with
             | Some _ as r -> r
             | None ->
-                walk_defns env_for_hover acc_te user_byte_lo lex_id offset full_tokens rest
+                walk_defns env_for_hover acc_te user_byte_lo lex_id offset
+                  full_tokens ~prelude_defn_cap_count ~idx:(idx + 1) rest
             ))
 
-let hover_type_for_identifier ~(prelude : bool) ~(src_path : string)
-    ~(source : string) ~(line0 : int) ~(char0 : int) : (string, string) result =
+type hover_kind =
+  | HoverType
+  | HoverDefinition
+
+type hover_result = hover_kind * string
+
+let find_type_definition_by_name (defs : c_defn list) (name : string) :
+    c_defn option =
+  let rec walk = function
+    | [] -> None
+    | d :: rest -> (
+        match d with
+        | CTypeAlias (n, _, _) when String.equal n name -> Some d
+        | CSumType (n, _, _) when String.equal n name -> Some d
+        | CSumTypeRec (n, _, _) when String.equal n name -> Some d
+        | CSumTypeRecMutRec group ->
+            if List.exists (fun (n, _, _) -> String.equal n name) group then
+              Some (CSumTypeRecMutRec group)
+            else walk rest
+        | _ -> walk rest)
+  in
+  walk defs
+
+let hover_string_of_type_params (args : string list) : string =
+  match args with
+  | [] -> ""
+  | _ -> "<" ^ String.concat ", " args ^ ">"
+
+let hover_string_of_sum_ctors (ctors : (string * c_type option) list) : string =
+  String.concat "\n  "
+    (List.map
+       (fun (cons_name, payload_type_opt) ->
+         match payload_type_opt with
+         | None -> "| " ^ cons_name
+         | Some payload_type ->
+             "| " ^ cons_name ^ " of " ^ hover_string_of_c_type payload_type)
+       ctors)
+
+let hover_string_of_type_defn (d : c_defn) : string =
+  match d with
+  | CTypeAlias (name, args, body) ->
+      "type " ^ name ^ hover_string_of_type_params args ^ " = "
+      ^ hover_string_of_mono body
+  | CSumType (name, args, ctors) ->
+      "type " ^ name ^ hover_string_of_type_params args ^ " = "
+      ^ hover_string_of_sum_ctors ctors
+  | CSumTypeRec (name, args, ctors) ->
+      "type rec " ^ name ^ hover_string_of_type_params args ^ " = "
+      ^ hover_string_of_sum_ctors ctors
+  | CSumTypeRecMutRec types ->
+      String.concat "\n"
+        (List.mapi
+           (fun i (name, args, ctors) ->
+             let prefix = if i = 0 then "type rec " else "and " in
+             prefix ^ name ^ hover_string_of_type_params args ^ " = "
+             ^ hover_string_of_sum_ctors ctors)
+           types)
+  | _ -> C_to_string.string_of_defn d
+
+let hover_type_definition_at_offset (defs : c_defn list) (tokens : Lex.token list)
+    (offset : int) : string option =
+  match lexer_id_covering_offset tokens offset with
+  | None -> None
+  | Some (name, _, _) -> (
+      match find_type_definition_by_name defs name with
+      | Some d -> Some (hover_string_of_type_defn d)
+      | None -> None)
+
+let hover_for_position ~(prelude : bool) ~(src_path : string) ~(source : string)
+    ~(line0 : int) ~(char0 : int) : (hover_result, string) result =
   let full_source = Prelude.prepend_to_source ~enabled:prelude ~src_path source in
   let user_off = byte_offset_of_line_char source line0 char0 in
   let delta = String.length full_source - String.length source in
@@ -1096,13 +1185,26 @@ let hover_type_for_identifier ~(prelude : bool) ~(src_path : string)
       clear_id_queue ();
       let static_env = build_full_static_env () in
       let type_env : type_env = [] in
-      let ctor_env : constructor_env = [] in
-      match typecheck_defns_hover static_env type_env ctor_env condensed with
-      | Error e -> Error (string_of_type_check_error e)
-      | Ok (_env, te, _) -> (
-          match
-            walk_defns static_env te user_byte_lo lex_id_at_offset offset full_tokens condensed
-          with
-          | Some s -> Ok s
-          | None -> Error "no typed identifier at this position"
-          ))
+      match
+        walk_defns static_env type_env user_byte_lo lex_id_at_offset offset
+          full_tokens ~prelude_defn_cap_count:prelude_n ~idx:0 condensed
+      with
+      | Some s -> Ok (HoverType, s)
+      | None -> (
+          let op_or_id_type_fallback =
+            match lex_id_at_offset with
+            | Some name -> type_string_for_id static_env type_env name
+            | None -> None
+          in
+          match op_or_id_type_fallback with
+          | Some s -> Ok (HoverType, s)
+          | None -> (
+              match hover_type_definition_at_offset condensed full_tokens offset with
+              | Some s -> Ok (HoverDefinition, s)
+              | None -> Error "no typed identifier at this position" ) ) )
+
+let hover_type_for_identifier ~(prelude : bool) ~(src_path : string)
+    ~(source : string) ~(line0 : int) ~(char0 : int) : (string, string) result =
+  match hover_for_position ~prelude ~src_path ~source ~line0 ~char0 with
+  | Ok (_, s) -> Ok s
+  | Error e -> Error e

--- a/test/hover_ident_tests.ml
+++ b/test/hover_ident_tests.ml
@@ -50,6 +50,35 @@ and is_odd n =
              (* Cursor on first [^] inside [(^^)]. *)
              assert_equal ~printer:Fun.id "a -> b -> a"
                (hover ~prelude:false ~source ~line0:0 ~char0:5) );
+         ( "pattern_binding_common_name_prefers_user_scope" >:: fun _ ->
+             let source =
+               {|let s :: t = [1,2]
+let _ = s
+|}
+             in
+             assert_equal ~printer:Fun.id "Int"
+               (hover ~prelude:true ~source ~line0:0 ~char0:4) );
+         ( "prefix_operator_hover_parenthesized_builtin" >:: fun _ ->
+             let source = "let _ = (+) 1 2\n" in
+             assert_equal ~printer:Fun.id "Int -> Int -> Int"
+               (hover ~prelude:false ~source ~line0:0 ~char0:9) );
+         ( "type_name_hover_shows_type_definition" >:: fun _ ->
+             let source =
+               {|type Box<a> = a
+let id (x : Box<Int>) = x
+|}
+             in
+             assert_equal ~printer:Fun.id "type Box<a> = a"
+               (hover ~prelude:false ~source ~line0:1 ~char0:12) );
+         ( "hover_survives_unrelated_type_error_later" >:: fun _ ->
+             let source =
+               {|let x = 1
+let broken = x + true
+let y = x
+|}
+             in
+             assert_equal ~printer:Fun.id "Int"
+               (hover ~prelude:false ~source ~line0:2 ~char0:4) );
        ]
 
 let () = run_test_tt_main suite

--- a/vscode-forge/src/server.ts
+++ b/vscode-forge/src/server.ts
@@ -13,61 +13,10 @@ import {
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-/** Stub: skip obvious keywords so hovers look vaguely sensible. */
-const RESERVED = new Set([
-  "let",
-  "in",
-  "fn",
-  "case",
-  "do",
-  "end",
-  "type",
-  "rec",
-  "impl",
-  "for",
-  "where",
-  "if",
-  "then",
-  "else",
-  "match",
-  "with",
-  "data",
-  "fun",
-  "open",
-  "import",
-  "module",
-  "of",
-  "and",
-  "or",
-  "not",
-  "true",
-  "false",
-]);
-
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 
 let clientForgeHoverPath: string | undefined;
-
-function wordAt(doc: TextDocument, position: Position): string | null {
-  const line = doc
-    .getText({
-      start: { line: position.line, character: 0 },
-      end: { line: position.line + 1, character: 0 },
-    })
-    .replace(/\r?\n$/, "");
-  const ch = position.character;
-  const re = /[a-zA-Z_][a-zA-Z0-9_']*/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(line)) !== null) {
-    const start = m.index;
-    const end = start + m[0].length;
-    if (ch >= start && ch < end) {
-      return m[0];
-    }
-  }
-  return null;
-}
 
 function uriToFsPath(uri: string): string | null {
   try {
@@ -148,12 +97,13 @@ function runForgeHover(
   line0: number,
   char0: number,
   source: string
-): Promise<string | null> {
+): Promise<{ kind: "type" | "definition"; text: string } | null> {
   const args = [srcPathForTool, "1", String(line0), String(char0)];
   return new Promise((resolve) => {
     const child = spawn(exe, args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
+
     let stdout = "";
     let stderr = "";
     child.stdout?.on("data", (d: Buffer) => {
@@ -176,7 +126,15 @@ function runForgeHover(
         resolve(null);
         return;
       }
-      resolve(trimmed);
+      if (trimmed.startsWith("TYPE\t")) {
+        resolve({ kind: "type", text: trimmed.slice("TYPE\t".length) });
+        return;
+      }
+      if (trimmed.startsWith("DEF\t")) {
+        resolve({ kind: "definition", text: trimmed.slice("DEF\t".length) });
+        return;
+      }
+      resolve({ kind: "type", text: trimmed });
     });
     const stdin = child.stdin;
     if (!stdin) {
@@ -203,40 +161,51 @@ connection.onInitialize((params: InitializeParams) => {
 });
 
 connection.onHover(async (params): Promise<Hover | null> => {
-  const doc = documents.get(params.textDocument.uri);
-  if (!doc) {
+  try {
+    const doc = documents.get(params.textDocument.uri);
+    if (!doc) {
+      return null;
+    }
+
+    const exe = resolveForgeHoverExecutable(params.textDocument.uri);
+    if (!exe) {
+      return null;
+    }
+
+    const fsPath = uriToFsPath(params.textDocument.uri);
+    const srcPathForTool = fsPath ?? "untitled.ls";
+
+    const hoverInfo = await runForgeHover(
+      exe,
+      srcPathForTool,
+      params.position.line,
+      params.position.character,
+      doc.getText()
+    );
+    if (!hoverInfo) {
+      return null;
+    }
+
+    if (hoverInfo.kind === "definition") {
+      const def = hoverInfo.text.replace(/```/g, "\\`\\`\\`");
+      return {
+        contents: {
+          kind: "markdown",
+          value: `**Definition:**\n\`\`\`forge\n${def}\n\`\`\``,
+        },
+      };
+    }
+
+    return {
+      contents: {
+        kind: "markdown",
+        value: `**Type:** \`${hoverInfo.text.replace(/`/g, "\\`")}\``,
+      },
+    };
+  } catch (err) {
+    connection.console.warn(`[forge] onHover failed: ${String(err)}`);
     return null;
   }
-  const word = wordAt(doc, params.position);
-  if (!word || RESERVED.has(word)) {
-    return null;
-  }
-
-  const exe = resolveForgeHoverExecutable(params.textDocument.uri);
-  if (!exe) {
-    return null;
-  }
-
-  const fsPath = uriToFsPath(params.textDocument.uri);
-  const srcPathForTool = fsPath ?? "untitled.ls";
-
-  const typeStr = await runForgeHover(
-    exe,
-    srcPathForTool,
-    params.position.line,
-    params.position.character,
-    doc.getText()
-  );
-  if (!typeStr) {
-    return null;
-  }
-
-  return {
-    contents: {
-      kind: "markdown",
-      value: `**Type:** \`${typeStr.replace(/`/g, "\\`")}\``,
-    },
-  };
 });
 
 documents.listen(connection);


### PR DESCRIPTION
## Summary

This PR fixes hover reliability and accuracy in the IDE extension/language server pipeline.

### What’s fixed

- Hover now shows type **definitions** when hovering type names (e.g. `type Box<a> = a`).
- Hover correctly reports inferred types for identifiers introduced via patterns (including cases that previously collided with prelude names).
- Hover supports binary operators in prefix/parenthesized form more reliably.
- Hover no longer effectively "dies" after typecheck failures in the file:
  - backend now handles definition/typecheck failures and exceptions defensively
  - hover continues with best-effort behavior instead of crashing the request flow

## Implementation details

### Backend (`src/hover_query.ml`)

- Added richer hover result shape:
  - `HoverType`
  - `HoverDefinition`
- Kept compatibility by preserving `hover_type_for_identifier` as a wrapper.
- Added type-definition lookup/rendering from condensed defns:
  - `CTypeAlias`
  - `CSumType`
  - `CSumTypeRec`
  - `CSumTypeRecMutRec`
- Normalized definition display to avoid internal written metavars leaking into hover text.
- Improved traversal behavior:
  - do not let a single failing definition halt all hover resolution
  - catch exceptions around defn generation/hover-in-defn to prevent request failure
  - continue scanning later defs with accumulated environment where possible
- Added operator/id fallback typing when AST-site matching misses.

### Hover CLI (`bin/forge_hover.ml`)

- Output is now structured:
  - `TYPE\t...`
  - `DEF\t...`
- Retains existing error contract (`ERROR: ...` + non-zero exit).

### VS Code server (`vscode-forge/src/server.ts`)

- Parses structured hover output and renders:
  - `**Type:** ...`
  - `**Definition:**` fenced code block
- Keeps hover handler defensive (`try/catch`) so server stays responsive on failures.

## Tests

Updated `test/hover_ident_tests.ml` with regressions for:

- Pattern-bound identifier type correctness (including prelude-name collision scenarios).
- Prefix operator hover type.
- Type-name hover returning definition text.
- Hover resilience when unrelated type errors exist in the same file.

All tests pass locally (`dune runtest`).

## Notes

- This branch intentionally includes only hover/IDE-related files.
- Unrelated local working-tree edits were left untouched.
